### PR TITLE
Feature: Add player confidence feedback

### DIFF
--- a/internal/domain/games/cmd.go
+++ b/internal/domain/games/cmd.go
@@ -54,17 +54,19 @@ func NewJoinGameCommand(gameID, userID string) (*JoinGameCommand, error) {
 
 // VoteCommand is a user voting command.
 type VoteCommand struct {
-	GameID string
-	UserID string
-	Vote   Card
+	GameID     string
+	UserID     string
+	Vote       Card
+	Confidence string
 }
 
 // NewVoteCommand creates a new command instance.
-func NewVoteCommand(gameID, userID string, card Card) (*VoteCommand, error) {
+func NewVoteCommand(gameID, userID string, card Card, confidence string) (*VoteCommand, error) {
 	return &VoteCommand{
-		GameID: gameID,
-		UserID: userID,
-		Vote:   card,
+		GameID:     gameID,
+		UserID:     userID,
+		Vote:       card,
+		Confidence: confidence,
 	}, nil
 }
 

--- a/internal/domain/games/game.go
+++ b/internal/domain/games/game.go
@@ -16,6 +16,8 @@ const (
 	GameStateStarted = "started"
 	// GameStateFinished represents finished game state.
 	GameStateFinished = "finished"
+	// ConfidenceNormal represents default confidence level.
+	ConfidenceNormal = "normal"
 )
 
 // Game is a domain aggregate that represents one single game.
@@ -32,9 +34,10 @@ type Game struct {
 
 // Player is an entity of a game player with state.
 type Player struct {
-	VotedCard *Card
-	CanReveal bool
-	Active    bool
+	VotedCard  *Card
+	Confidence string
+	CanReveal  bool
+	Active     bool
 }
 
 // NewGame creates a new game aggregate instance.
@@ -192,6 +195,7 @@ func (g *Game) Vote(cmd VoteCommand) error {
 	}
 
 	g.players[cmd.UserID].VotedCard = &cmd.Vote
+	g.players[cmd.UserID].Confidence = cmd.Confidence
 
 	g.setChanged()
 
@@ -227,6 +231,7 @@ func (g *Game) UnVote(cmd UnVoteCommand) error {
 	}
 
 	g.players[cmd.UserID].VotedCard = nil
+	g.players[cmd.UserID].Confidence = ConfidenceNormal
 
 	g.setChanged()
 

--- a/internal/domain/games/service_test.go
+++ b/internal/domain/games/service_test.go
@@ -193,7 +193,7 @@ func TestGamesService_Vote(t *testing.T) {
 			srv, err := games.NewService(tt.gameRepo, eventBusStub{})
 			require.NoError(t, err)
 
-			cmd, err := games.NewVoteCommand("anything", test.User1, *card)
+			cmd, err := games.NewVoteCommand("anything", test.User1, *card, games.ConfidenceNormal)
 			require.NoError(t, err)
 
 			err = srv.Vote(*cmd)

--- a/internal/domain/state/state.go
+++ b/internal/domain/state/state.go
@@ -10,10 +10,11 @@ import (
 
 // PlayerState represents a player state.
 type PlayerState struct {
-	UserID    string
-	Name      string
-	VotedCard *games.Card
-	CanReveal bool
+	UserID     string
+	Name       string
+	VotedCard  *games.Card
+	Confidence string
+	CanReveal  bool
 }
 
 // GameState represents a game state.
@@ -44,10 +45,11 @@ func NewStateForGame(game games.Game, gamers []users.User) GameState {
 		}
 
 		state.Players = append(state.Players, PlayerState{
-			UserID:    uid,
-			Name:      userName,
-			VotedCard: p.VotedCard,
-			CanReveal: p.CanReveal,
+			UserID:     uid,
+			Name:       userName,
+			VotedCard:  p.VotedCard,
+			Confidence: p.Confidence,
+			CanReveal:  p.CanReveal,
 		})
 	}
 

--- a/internal/infra/async/pool.go
+++ b/internal/infra/async/pool.go
@@ -224,14 +224,19 @@ func (p *API) leave(conn socketio.Conn) string {
 	return "ok"
 }
 
-func (p *API) vote(conn socketio.Conn, vote string) string {
+type votePayload struct {
+	Vote       string `json:"vote"`
+	Confidence string `json:"confidence"`
+}
+
+func (p *API) vote(conn socketio.Conn, payload votePayload) string {
 	cc, ok := conn.Context().(conContext)
 	if !ok {
 		logrus.Errorf("socket game: unable to get the context")
 		return genericErrorMessage
 	}
 
-	vote, err := url.QueryUnescape(vote)
+	vote, err := url.QueryUnescape(payload.Vote)
 	if err != nil {
 		logrus.Errorf("socket leave game: failed to unescape vote: %v", err)
 		return genericErrorMessage
@@ -243,7 +248,7 @@ func (p *API) vote(conn socketio.Conn, vote string) string {
 		return genericErrorMessage
 	}
 
-	cmd, err := games.NewVoteCommand(cc.gameID, cc.userID, *card)
+	cmd, err := games.NewVoteCommand(cc.gameID, cc.userID, *card, payload.Confidence)
 	if err != nil {
 		logrus.Errorf("vote: %v", err)
 		return genericErrorMessage

--- a/internal/infra/repository/game_dto.go
+++ b/internal/infra/repository/game_dto.go
@@ -38,9 +38,10 @@ func (d cardsDeckDTO) toDomain() (*games.CardsDeck, error) {
 }
 
 type playerDTO struct {
-	VotedCard string `json:"voted_card"`
-	CanReveal bool   `json:"can_reveal"`
-	Active    bool   `json:"active"`
+	VotedCard  string `json:"voted_card"`
+	CanReveal  bool   `json:"can_reveal"`
+	Confidence string `json:"confidence"`
+	Active     bool   `json:"active"`
 }
 
 func (d playerDTO) toDomain() (*games.Player, error) {
@@ -55,9 +56,10 @@ func (d playerDTO) toDomain() (*games.Player, error) {
 	}
 
 	return &games.Player{
-		VotedCard: votedCard,
-		CanReveal: d.CanReveal,
-		Active:    d.Active,
+		VotedCard:  votedCard,
+		CanReveal:  d.CanReveal,
+		Confidence: d.Confidence,
+		Active:     d.Active,
 	}, nil
 }
 

--- a/internal/infra/repository/games.go
+++ b/internal/infra/repository/games.go
@@ -70,9 +70,10 @@ func (r *MemoryGameRepository) Save(game *games.Game) error {
 			votedCard = p.VotedCard.Type()
 		}
 		dto.Players[id] = playerDTO{
-			VotedCard: votedCard,
-			CanReveal: p.CanReveal,
-			Active:    p.Active,
+			VotedCard:  votedCard,
+			CanReveal:  p.CanReveal,
+			Active:     p.Active,
+			Confidence: p.Confidence,
 		}
 	}
 

--- a/internal/infra/transformers/gamestate.go
+++ b/internal/infra/transformers/gamestate.go
@@ -8,8 +8,9 @@ import (
 
 // PlayerStateResponse is a response payload for a player.
 type PlayerStateResponse struct {
-	Name      string `json:"name"`
-	VotedCard string `json:"voted_card"`
+	Name       string `json:"name"`
+	VotedCard  string `json:"voted_card"`
+	Confidence string `json:"confidence"`
 }
 
 func newPlayerStateResponse(gState state.GameState, pState state.PlayerState) PlayerStateResponse {
@@ -21,6 +22,7 @@ func newPlayerStateResponse(gState state.GameState, pState state.PlayerState) Pl
 			resp.VotedCard = games.NewUnrevealedCard().Type()
 		} else {
 			resp.VotedCard = pState.VotedCard.Type()
+			resp.Confidence = pState.Confidence
 		}
 	}
 	return resp
@@ -41,13 +43,14 @@ func newCardsDeckResponse(cd games.CardsDeck) cardsDeckResponse {
 
 // GameStateResponse is a response payload with game state.
 type GameStateResponse struct {
-	Name      string                `json:"name"`
-	TicketURL string                `json:"ticket_url"`
-	CardsDeck cardsDeckResponse     `json:"cards_deck"`
-	Players   []PlayerStateResponse `json:"players"`
-	State     string                `json:"state"`
-	VotedCard string                `json:"voted_card"`
-	CanReveal bool                  `json:"can_reveal"`
+	Name       string                `json:"name"`
+	TicketURL  string                `json:"ticket_url"`
+	CardsDeck  cardsDeckResponse     `json:"cards_deck"`
+	Players    []PlayerStateResponse `json:"players"`
+	State      string                `json:"state"`
+	VotedCard  string                `json:"voted_card"`
+	Confidence string                `json:"confidence"`
+	CanReveal  bool                  `json:"can_reveal"`
 }
 
 // NewGameStateResponse creates a new game state response.
@@ -61,6 +64,7 @@ func NewGameStateResponse(state state.GameState, player state.PlayerState) GameS
 	}
 	if player.VotedCard != nil {
 		resp.VotedCard = player.VotedCard.Type()
+		resp.Confidence = player.Confidence
 	}
 	for _, p := range state.Players {
 		resp.Players = append(resp.Players, newPlayerStateResponse(state, p))

--- a/test/domain_test.go
+++ b/test/domain_test.go
@@ -53,12 +53,12 @@ func TestWorkflow(t *testing.T) {
 	err = gamesService.Join(*joinCmd)
 	require.NoError(t, err)
 
-	voteCmd, err := games.NewVoteCommand(gameID, user1.ID(), "XS")
+	voteCmd, err := games.NewVoteCommand(gameID, user1.ID(), "XS", games.ConfidenceNormal)
 	require.NoError(t, err)
 	err = gamesService.Vote(*voteCmd)
 	require.NoError(t, err)
 
-	voteCmd, err = games.NewVoteCommand(gameID, user2.ID(), "?")
+	voteCmd, err = games.NewVoteCommand(gameID, user2.ID(), "?", games.ConfidenceNormal)
 	require.NoError(t, err)
 	err = gamesService.Vote(*voteCmd)
 	require.NoError(t, err)

--- a/test/game_helpers.go
+++ b/test/game_helpers.go
@@ -59,7 +59,7 @@ func (g *Game) UserJoins(uid string) *Game {
 func (g *Game) UserVotes(uid, cardName string) *Game {
 	card, err := games.NewCard(cardName)
 	require.NoError(g.t, err)
-	cmd, err := games.NewVoteCommand(g.game.ID(), uid, *card)
+	cmd, err := games.NewVoteCommand(g.game.ID(), uid, *card, games.ConfidenceNormal)
 	require.NoError(g.t, err)
 	g.lastError = g.game.Vote(*cmd)
 	return g

--- a/web/src/components/Card.vue
+++ b/web/src/components/Card.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="card">
-    <button
-        :class="cardClass"
-        @click="$emit('click')"
-        translate="no">
-      {{ value }}
-    </button>
+    <div :class="cardClass" @click="$emit('click')" translate="no">
+      <div v-if="active && confidence==='high'" class="card-btn-active-label">!</div>
+      <div v-if="active && confidence==='low'" class="card-btn-active-label">?</div>
+      <div v-if="active && confidence==='normal'" class="card-btn-active-label"></div>
+      <div class="card-content">{{ value }}</div>
+    </div>
   </div>
 </template>
 
@@ -14,6 +14,7 @@ export default {
   props: {
     active: Boolean,
     value: String,
+    confidence: String,
   },
 
   data: () => {
@@ -22,8 +23,11 @@ export default {
 
   computed: {
     cardClass() {
-      return this.active ? "card card-btn-active" : "card card-btn-inactive"
-    }
+      if (!this.active) {
+        return "card card-btn-inactive"
+      }
+      return "card card-btn-active"
+    },
   },
 
   methods: {},
@@ -39,6 +43,7 @@ export default {
 
   margin .4rem .4rem
   display inline-block
+  position relative
   vertical-align top
   white-space nowrap
   transition all .1s linear
@@ -46,22 +51,42 @@ export default {
   outline: 0;
   cursor: pointer;
 
+.card-content
+  display: flex;
+  align-items: center;
+  justify-content center;
+  flex-direction: column;
+  width: 2.7rem;
+  height: 5rem;
+
 .card-btn-inactive:hover
   margin-top: -.005rem;
   box-shadow: 0 3px 5px #888888;
   transition all .1s linear
 
 .card-btn-inactive
-  border: 2px solid #23D2AA;
+  border: 2px solid #A0A0A0;
 
 .card-btn-active
-  color: #fff;
-  background: #20C29A;
-  border-color: transparent;
-  margin-top: -.8rem;
+  border: 2px solid #13C29A;
+  margin-top: -.5rem;
 
 .card-btn-active:hover
   box-shadow: 0 3px 5px #888888;
   transition all .1s linear
+
+.card-btn-active-label
+  position absolute
+  top 0
+  left 0
+  width 100%
+  height 20px
+  border-top-left-radius .3rem
+  border-top-right-radius .3rem
+  background #13C29A
+  color white
+  font-size 13px
+  text-align center
+  font-weight bold
 
 </style>

--- a/web/src/components/CardOnTable.vue
+++ b/web/src/components/CardOnTable.vue
@@ -2,7 +2,26 @@
   <div class="tcard">
     <div v-if="card===''" class="tcard-body-placeholder"></div>
     <div v-else-if="card==='*'" class="tcard-body-back"></div>
-    <div v-else class="tcard-body">{{ card }}</div>
+    <div v-else class="tcard-body">
+
+      <v-tooltip top>
+        <template v-slot:activator="{ on, attrs }">
+          <div v-if="confidence==='high'" v-bind="attrs" v-on="on" class="tcard-label">!</div>
+        </template>
+        <span>Very confident</span>
+      </v-tooltip>
+
+      <v-tooltip top>
+        <template v-slot:activator="{ on, attrs }">
+          <div v-if="confidence==='low'" v-bind="attrs" v-on="on" class="tcard-label">?</div>
+        </template>
+        <span>Not sure</span>
+      </v-tooltip>
+
+      <div v-if="confidence==='normal'" class="tcard-label"></div>
+
+      {{ card }}
+    </div>
     <div class="tcard-name">{{ name }}</div>
   </div>
 </template>
@@ -12,16 +31,11 @@ export default {
   props: {
     card: String,
     name: String,
+    confidence: String,
   },
 
   data: () => {
     return {}
-  },
-
-  computed: {
-    cardClass() {
-      return this.put ? "tcard-body" : "tcard-body-placeholder"
-    }
   },
 
   methods: {},
@@ -29,6 +43,19 @@ export default {
 </script>
 
 <style lang="stylus">
+.tcard-label
+  position: absolute
+  top: 0
+  left: 0
+  width: 100%
+  height: 25px
+  border-top-left-radius .8rem
+  border-top-right-radius .8rem
+  background #13C29A
+  color white
+  text-align center
+  font-size 17px
+
 .tcard
   display: flex;
   align-items: center;
@@ -50,8 +77,8 @@ export default {
   height: 7rem;
   border-radius: .8rem;
   background: linear-gradient(-135deg, rgb(35, 210, 170) 10%, transparent),
-  repeating-linear-gradient(45deg, rgba(35, 210, 170, 1) 0%, rgba(35, 150, 100, 0.6) 5%, transparent 5%, transparent 10%),
-  repeating-linear-gradient(-45deg, rgba(35, 210, 170, 0.4) 0%, rgba(35, 150, 100, 0.5) 5%, transparent 5%, transparent 10%);
+      repeating-linear-gradient(45deg, rgba(35, 210, 170, 1) 0%, rgba(35, 150, 100, 0.6) 5%, transparent 5%, transparent 10%),
+      repeating-linear-gradient(-45deg, rgba(35, 210, 170, 0.4) 0%, rgba(35, 150, 100, 0.5) 5%, transparent 5%, transparent 10%);
   background-color: rgba(35, 210, 170, 0.25);
 
 .tcard-body

--- a/web/src/models/game.js
+++ b/web/src/models/game.js
@@ -34,8 +34,11 @@ export default {
         notifier.socket.emit("leave")
     },
 
-    async vote(gameID, vote) {
-        notifier.socket.emit("vote", vote)
+    async vote(gameID, vote, confidence) {
+        notifier.socket.emit("vote", {
+            vote: vote,
+            confidence: confidence,
+        })
     },
 
     async reveal() {

--- a/web/src/models/state.js
+++ b/web/src/models/state.js
@@ -13,6 +13,7 @@ export default class {
     players;
     voted_card;
     can_reveal;
+    confidence;
 
     constructor(id) {
         this.id = id
@@ -50,6 +51,10 @@ export default class {
         return this.voted_card === card
     }
 
+    voted() {
+        return this.voted_card !== ""
+    }
+
     async reveal() {
         await game.reveal(this.id)
     }
@@ -65,8 +70,16 @@ export default class {
         } else {
             card = encodeURIComponent(card)
             this.voted_card = card
-            await game.vote(this.id, card)
+            this.confidence = "normal"
+            await game.vote(this.id, card, this.confidence)
         }
+    }
+
+    async changeConfidence(confidence) {
+        if (!this.voted_card || this.voted_card === "") {
+            return
+        }
+        await game.vote(this.id, this.voted_card, confidence)
     }
 
     stopUpdates() {

--- a/web/src/views/Game.vue
+++ b/web/src/views/Game.vue
@@ -46,7 +46,7 @@
 
     <v-row align="center" justify="center" v-if="state">
       <card-on-table v-for="player in state.getPlayers()" v-bind:key="player.name" :name="player.name"
-                     :card="player.voted_card"></card-on-table>
+                     :card="player.voted_card" :confidence="player.confidence"></card-on-table>
     </v-row>
 
     <v-row align="center" justify="center" v-if="state" style="min-height: 100px;">
@@ -55,18 +55,31 @@
       <div v-if="state.isRunning() && !state.canReveal()">Please pick your cards</div>
     </v-row>
 
-    <v-row align="center" justify="center" v-if="state" v-show="state.isRunning()" style="min-height: 100px;">
-      <Card v-for="card in state.getCards()"
-            v-bind:key="card"
-            @click="state.vote(card)"
-            :active="state.isActive(card)"
-            :value="card">
-      </Card>
-    </v-row>
+    <v-container v-if="state" v-show="state.isRunning()" style="height: 200px;">
+      <v-row align="center" justify="center" style="min-height: 100px;">
+          <Card v-for="card in state.getCards()"
+                v-bind:key="card"
+                @click="state.vote(card)"
+                :active="state.isActive(card)"
+                :value="card"
+                :confidence="state.confidence">
+          </Card>
+      </v-row>
+      <v-row v-if="state.voted() && state.confidence" align="center" justify="center" style="min-height: 50px; margin-top: 30px;">
+        <v-btn-toggle @change="(val)=>state.changeConfidence(val)" v-model="state.confidence" tile group mandatory>
+          <v-btn value="low">Not sure</v-btn>
+          <v-btn value="normal">Default</v-btn>
+          <v-btn value="high">Very confident</v-btn>
+        </v-btn-toggle>
+      </v-row>
+    </v-container>
 
-    <v-row align="center" justify="center" v-if="state" v-show="state.isFinished()" style="min-height: 100px;">
-      <h1>Voting finished</h1>
-    </v-row>
+    <v-container v-if="state" v-show="state.isFinished()" style="height: 200px;">
+      <v-row align="center" justify="center">
+        <h1>Voting finished</h1>
+      </v-row>
+    </v-container>
+
     <UserNameDialog ref="userNameDialog"></UserNameDialog>
     <GameSettingsDialog ref="gameSettingsDialog"></GameSettingsDialog>
     <InviteDialog ref="inviteDialog"></InviteDialog>


### PR DESCRIPTION
The feature adds a new functionality - allow a player to specify the level of confidence -
- "Not sure"
- "Normal"
- "Very confident"

It gives an opportunity to give more information with a single vote and makes results more focused on correctness and helps to force further discussions, e.g. clarify some ticket details and be sure that all the team members understand the estimated work the same way.